### PR TITLE
Add BasicCombat sample for turn-based gameplay demonstration

### DIFF
--- a/dee-dee-r.dnd-sdk/CHANGELOG.md
+++ b/dee-dee-r.dnd-sdk/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Phase 16 — BasicCombat Sample
+
+- **`BasicCombatManager`** (`DeeDeeR.DnD.Samples.BasicCombat`) — coroutine-driven two-character combat loop. Rolls initiative via `InitiativeSystem`; sorts by result (ties to the player); loops rounds until one side reaches 0 HP. Player turn: activates `PlayerActionMenu` and yields on `WaitUntil(TurnComplete)`. Enemy turn: attacks with main-hand weapon via `CombatantComponent.PerformAttack`; yields one frame for signal propagation. At end of combat, publishes `CharacterDied` for the loser (game-side SDK contract) and logs the winner.
+- **`PlayerActionMenu`** (`DeeDeeR.DnD.Samples.BasicCombat`) — Unity UI panel (requires `Button` references). **Attack** button calls `CombatantComponent.PerformAttack` and sets `ActionUsed = true` (game's action-economy responsibility). **End Turn** button hides the panel and sets `TurnComplete = true`. Attack button is disabled when `ActionUsed` is set. Activated each turn by `BasicCombatManager.BeginPlayerTurn`.
+- **`CombatLogger`** (`DeeDeeR.DnD.Samples.BasicCombat`) — subscribes to six `DnDSdkBus` combat signals in `OnEnable` and unsubscribes in `OnDisable`: `TurnStarted`, `AttackMade`, `CriticalHit`, `DamageDealt`, `HitPointsChanged`, `CharacterDied`. Logs every event to the Unity Console. Demonstrates the bus as the SDK ↔ game seam: no reference to `CombatSystem` or combatant GameObjects.
+- **`dee-dee-r.dnd-sdk.samples.basiccombat.asmdef`** — sample assembly. References `dee-dee-r.dnd-sdk.core`, `dee-dee-r.dnd-sdk.runtime`, `Dee-Dee-R.Message-Bus.Runtime`, `UnityEngine.UI`.
+
+#### Design notes — Phase 16
+- SDK contracts explicitly enforced by the sample (per architecture plan): `CharacterDied` published by game (not SDK) when HP reaches 0; `ActionUsed` set by game after `PerformAttack` (SDK only resets it in `StartTurn`); resistance/immunity not implemented (no `ResistanceResolver`) — raw damage passed directly to `ApplyDamage`.
+- The scene (`BasicCombat.unity`) must be created manually in the Unity Editor. Required GameObjects: `DnDSdkRunner` (with `FrameSchedulerBehaviour`), `CombatLogger`, `BasicCombatManager`, `Player` (`CharacterComponent` + `CombatantComponent`), `Enemy` (`CharacterComponent` + `CombatantComponent`), Canvas with `PlayerActionMenu` panel (two `Button` children).
+- Character data (`CharacterRecord`, `CharacterState`, `InventoryState`) must be populated at runtime or via the **DnD SDK → Character Creation Wizard**. At minimum, set `HitPoints.Maximum/Current` and `EquippedMainHand` on each combatant before entering Play mode.
+
 #### Phase 15 — PHB Data Asset Generator
 
 - **`PHBAssetGenerator`** (`DeeDeeR.DnD.Editor.DataGeneration`) — entry point; menu item **DnD SDK → Generate PHB Assets**. Runs all sub-generators inside `AssetDatabase.StartAssetEditing` / `StopAssetEditing` for a single import pass. Provides `GetOrCreate<T>(folder, name)`, `Load<T>(folder, name)`, and `EnsureFolder(parent, child)` helpers used by all sub-generators. Output root: `Assets/DnD SDK/Data/`.

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat.meta
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31124895fd76ea827b006d36f0ec20a7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts.meta
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 019d1c350b21595e498d013bbbc8ebf7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/BasicCombatManager.cs
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/BasicCombatManager.cs
@@ -1,0 +1,137 @@
+using System.Collections;
+using DeeDeeR.DnD.Core.Enums;
+using DeeDeeR.DnD.Core.Interfaces;
+using DeeDeeR.DnD.Runtime.Bus.Args;
+using DeeDeeR.DnD.Runtime.Components;
+using DeeDeeR.DnD.Runtime.Systems;
+using UnityEngine;
+
+namespace DeeDeeR.DnD.Samples.BasicCombat
+{
+    /// <summary>
+    /// Drives a two-character turn-based combat encounter using the DnD SDK.
+    /// Handles initiative, turn order, player UI hand-off, and a one-attack AI for the enemy.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>SDK contract reminders (enforced here, not by the SDK):</b>
+    /// <list type="bullet">
+    ///   <item><see cref="CharacterComponent.ApplyDamage"/> does not set the Unconscious condition
+    ///     or publish <see cref="CombatBusCategory.CharacterDied"/> when HP reaches 0 — this
+    ///     manager does both.</item>
+    ///   <item><c>ActionUsed</c> / <c>BonusActionUsed</c> / <c>ReactionUsed</c> are read here
+    ///     and in <see cref="PlayerActionMenu"/> to enforce the action economy; the SDK only
+    ///     resets them in <see cref="CombatantComponent.StartTurn"/>.</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public sealed class BasicCombatManager : MonoBehaviour
+    {
+        [Header("Combatants")]
+        [SerializeField] private CharacterComponent _playerCharacter;
+        [SerializeField] private CombatantComponent _playerCombatant;
+        [SerializeField] private CharacterComponent _enemyCharacter;
+        [SerializeField] private CombatantComponent _enemyCombatant;
+
+        [Header("UI")]
+        [SerializeField] private PlayerActionMenu _actionMenu;
+
+        private readonly InitiativeSystem _initiative = new InitiativeSystem();
+        private readonly IRollProvider    _roller     = new UnityRollProvider();
+
+        private void Start() => StartCombat();
+
+        /// <summary>Starts the combat coroutine. Can be called again after combat ends.</summary>
+        public void StartCombat() => StartCoroutine(CombatLoop());
+
+        // ── Combat loop ───────────────────────────────────────────────────────
+
+        private IEnumerator CombatLoop()
+        {
+            Debug.Log("[BasicCombat] ═══ Combat started! ═══");
+
+            // Roll initiative for both combatants.
+            int playerInit = _initiative.RollInitiative(
+                _playerCharacter.Record, _playerCharacter.State, _roller);
+            int enemyInit = _initiative.RollInitiative(
+                _enemyCharacter.Record, _enemyCharacter.State, _roller);
+
+            Debug.Log($"[BasicCombat] Initiative — " +
+                      $"{_playerCharacter.Record.Name}: {playerInit}, " +
+                      $"{_enemyCharacter.Record.Name}: {enemyInit}");
+
+            // Ties go to the player.
+            bool playerFirst = playerInit >= enemyInit;
+
+            var (first,  firstChar)  = playerFirst
+                ? (_playerCombatant, _playerCharacter)
+                : (_enemyCombatant,  _enemyCharacter);
+            var (second, secondChar) = playerFirst
+                ? (_enemyCombatant,  _enemyCharacter)
+                : (_playerCombatant, _playerCharacter);
+
+            int round = 0;
+            while (IsAlive(_playerCharacter) && IsAlive(_enemyCharacter))
+            {
+                round++;
+                Debug.Log($"[BasicCombat] ── Round {round} ──");
+
+                yield return ExecuteTurn(first, firstChar);
+                if (!IsAlive(_playerCharacter) || !IsAlive(_enemyCharacter)) break;
+
+                yield return ExecuteTurn(second, secondChar);
+            }
+
+            HandleCombatEnd();
+        }
+
+        private IEnumerator ExecuteTurn(CombatantComponent combatant, CharacterComponent self)
+        {
+            if (!IsAlive(self)) yield break;
+
+            var target = GetOpponent(self);
+            combatant.StartTurn();
+
+            if (combatant == _playerCombatant)
+            {
+                _actionMenu.BeginPlayerTurn(_playerCombatant, _playerCharacter, _enemyCharacter);
+                yield return new WaitUntil(() => _actionMenu.TurnComplete);
+            }
+            else
+            {
+                // Simple AI: attack the player with the main-hand weapon (if any).
+                var weapon = self.Inventory.EquippedMainHand;
+                if (weapon != null)
+                    combatant.PerformAttack(target, weapon, AdvantageState.Normal, _roller);
+                else
+                    Debug.Log($"[BasicCombat] {self.Record.Name} has no weapon — skips attack.");
+
+                yield return null; // pause one frame so signals propagate before EndTurn
+            }
+
+            combatant.EndTurn();
+        }
+
+        private void HandleCombatEnd()
+        {
+            // Identify winner and loser.
+            bool playerWon = IsAlive(_playerCharacter);
+            var loser  = playerWon ? _enemyCharacter  : _playerCharacter;
+            var winner = playerWon ? _playerCharacter : _enemyCharacter;
+
+            // SDK contract: game must publish CharacterDied when HP reaches 0.
+            DnDSdkRunner.Bus?.Combat.CharacterDied.PublishBroadcast(
+                new CharacterDiedArgs(loser.EndpointId));
+
+            Debug.Log($"[BasicCombat] ═══ Combat over! {winner.Record.Name} wins! ═══");
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────
+
+        private CharacterComponent GetOpponent(CharacterComponent ch)
+            => ch == _playerCharacter ? _enemyCharacter : _playerCharacter;
+
+        private static bool IsAlive(CharacterComponent ch)
+            => ch != null && ch.State.HitPoints.Current > 0;
+    }
+}

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/BasicCombatManager.cs.meta
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/BasicCombatManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 503dae22a7547af62a0e24a55446211d

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/CombatLogger.cs
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/CombatLogger.cs
@@ -1,0 +1,81 @@
+using DeeDeeR.DnD.Runtime.Bus.Args;
+using DeeDeeR.DnD.Runtime.Components;
+using DeeDeeR.MessageBus.Runtime.Core;
+using UnityEngine;
+
+namespace DeeDeeR.DnD.Samples.BasicCombat
+{
+    /// <summary>
+    /// Subscribes to DnD SDK combat bus signals and logs them to the Unity Console.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This component demonstrates the message bus as the SDK ↔ game communication seam:
+    /// health bars, damage numbers, VFX, and audio triggers can all live here without
+    /// importing <c>CombatSystem</c> or holding direct references to combatants.
+    /// </para>
+    /// <para>
+    /// A fixed <see cref="EndpointId"/> (<c>"BasicCombatLogger"</c>) is used for subscription.
+    /// All subscriptions are broadcast — they receive signals from every combatant.
+    /// </para>
+    /// </remarks>
+    public sealed class CombatLogger : MonoBehaviour
+    {
+        private static readonly EndpointId _id = new EndpointId("BasicCombatLogger");
+
+        private void OnEnable()
+        {
+            var bus = DnDSdkRunner.Bus;
+            if (bus == null)
+            {
+                Debug.LogWarning("[CombatLogger] DnDSdkRunner.Bus is null — signals not subscribed. " +
+                                 "Ensure DnDSdkRunner is active before CombatLogger enables.");
+                return;
+            }
+
+            bus.Combat.TurnStarted.Subscribe(_id, OnTurnStarted);
+            bus.Combat.AttackMade.Subscribe(_id, OnAttackMade);
+            bus.Combat.CriticalHit.Subscribe(_id, OnCriticalHit);
+            bus.Combat.DamageDealt.Subscribe(_id, OnDamageDealt);
+            bus.Combat.HitPointsChanged.Subscribe(_id, OnHpChanged);
+            bus.Combat.CharacterDied.Subscribe(_id, OnCharacterDied);
+        }
+
+        private void OnDisable()
+        {
+            var bus = DnDSdkRunner.Bus;
+            if (bus == null) return;
+
+            bus.Combat.TurnStarted.UnsubscribeAll(_id);
+            bus.Combat.AttackMade.UnsubscribeAll(_id);
+            bus.Combat.CriticalHit.UnsubscribeAll(_id);
+            bus.Combat.DamageDealt.UnsubscribeAll(_id);
+            bus.Combat.HitPointsChanged.UnsubscribeAll(_id);
+            bus.Combat.CharacterDied.UnsubscribeAll(_id);
+        }
+
+        // ── Signal handlers ───────────────────────────────────────────────────
+
+        private static void OnTurnStarted(TurnArgs args)
+            => Debug.Log($"[CombatLogger] ▶ Turn started: {args.Character}");
+
+        private static void OnAttackMade(AttackMadeArgs args)
+            => Debug.Log($"[CombatLogger] ⚔ Attack: {args.Attacker} → {args.Target} " +
+                         $"| d20 roll: {args.Roll.Total} | Hit: {args.Roll.Hit} " +
+                         $"| Weapon: {args.Weapon.name}");
+
+        private static void OnCriticalHit(CritHitArgs args)
+            => Debug.Log($"[CombatLogger] ★ CRITICAL HIT! {args.Attacker} → {args.Target}");
+
+        private static void OnDamageDealt(DamageDealtArgs args)
+            => Debug.Log($"[CombatLogger] 💥 Damage: {args.Amount} {args.Type} " +
+                         $"({args.Attacker} → {args.Target})");
+
+        private static void OnHpChanged(HpChangedArgs args)
+            => Debug.Log($"[CombatLogger] ❤ HP: {args.Character}  " +
+                         $"{args.Previous} → {args.Current} / {args.Maximum}");
+
+        private static void OnCharacterDied(CharacterDiedArgs args)
+            => Debug.Log($"[CombatLogger] ✝ {args.Character} has died.");
+    }
+}

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/CombatLogger.cs.meta
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/CombatLogger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 997f415a4dafdc0ff9155cdbe6a37bff

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/PlayerActionMenu.cs
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/PlayerActionMenu.cs
@@ -1,0 +1,104 @@
+using DeeDeeR.DnD.Core.Enums;
+using DeeDeeR.DnD.Core.Interfaces;
+using DeeDeeR.DnD.Runtime.Components;
+using DeeDeeR.DnD.Runtime.Systems;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace DeeDeeR.DnD.Samples.BasicCombat
+{
+    /// <summary>
+    /// Simple action menu for the player's turn.
+    /// Shows an <b>Attack</b> button and an <b>End Turn</b> button.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="BasicCombatManager"/> calls <see cref="BeginPlayerTurn"/> at the start of the
+    /// player's turn and then waits on <see cref="TurnComplete"/> via <c>WaitUntil</c>.
+    /// </para>
+    /// <para>
+    /// <b>Action economy:</b> The Attack button is disabled once <c>ActionUsed</c> is set.
+    /// Setting <c>ActionUsed = true</c> is this menu's responsibility — the SDK only reads the
+    /// flag inside <see cref="CombatantComponent.StartTurn"/> to reset it.
+    /// </para>
+    /// </remarks>
+    public sealed class PlayerActionMenu : MonoBehaviour
+    {
+        [SerializeField] private GameObject _panel;
+        [SerializeField] private Button     _attackButton;
+        [SerializeField] private Button     _endTurnButton;
+
+        private CombatantComponent _combatant;
+        private CharacterComponent _character;
+        private CharacterComponent _target;
+
+        private readonly IRollProvider _roller = new UnityRollProvider();
+
+        /// <summary>
+        /// <c>true</c> once the player has pressed End Turn (or their action is spent and
+        /// they clicked End Turn). Polled by <see cref="BasicCombatManager"/> via
+        /// <c>WaitUntil</c>.
+        /// </summary>
+        public bool TurnComplete { get; private set; }
+
+        private void Awake()
+        {
+            _attackButton.onClick.AddListener(OnAttack);
+            _endTurnButton.onClick.AddListener(OnEndTurn);
+            _panel.SetActive(false);
+        }
+
+        // ── Public API ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Called by <see cref="BasicCombatManager"/> to activate the panel for the player's turn.
+        /// </summary>
+        public void BeginPlayerTurn(
+            CombatantComponent combatant,
+            CharacterComponent character,
+            CharacterComponent target)
+        {
+            _combatant   = combatant;
+            _character   = character;
+            _target      = target;
+            TurnComplete = false;
+            _panel.SetActive(true);
+            RefreshButtons();
+        }
+
+        // ── Button handlers ───────────────────────────────────────────────────
+
+        private void OnAttack()
+        {
+            if (_character.State.ActionUsed)
+                return;
+
+            var weapon = _character.Inventory.EquippedMainHand;
+            if (weapon == null)
+            {
+                Debug.Log("[BasicCombat] No weapon equipped — cannot attack.");
+                return;
+            }
+
+            // PerformAttack publishes AttackMade / DamageDealt / HitPointsChanged via the bus.
+            _combatant.PerformAttack(_target, weapon, AdvantageState.Normal, _roller);
+
+            // Game is responsible for marking the action as used.
+            _character.State.ActionUsed = true;
+            RefreshButtons();
+        }
+
+        private void OnEndTurn()
+        {
+            _panel.SetActive(false);
+            TurnComplete = true;
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────
+
+        private void RefreshButtons()
+        {
+            _attackButton.interactable = !_character.State.ActionUsed;
+        }
+    }
+}

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/PlayerActionMenu.cs.meta
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/Scripts/PlayerActionMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e32bd1df31ce99266b20545fab23763b

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/dee-dee-r.dnd-sdk.samples.basiccombat.asmdef
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/dee-dee-r.dnd-sdk.samples.basiccombat.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "dee-dee-r.dnd-sdk.samples.basiccombat",
+    "rootNamespace": "DeeDeeR.DnD.Samples.BasicCombat",
+    "references": [
+        "dee-dee-r.dnd-sdk.core",
+        "dee-dee-r.dnd-sdk.runtime",
+        "Dee-Dee-R.Message-Bus.Runtime",
+        "UnityEngine.UI"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/dee-dee-r.dnd-sdk/Samples/BasicCombat/dee-dee-r.dnd-sdk.samples.basiccombat.asmdef.meta
+++ b/dee-dee-r.dnd-sdk/Samples/BasicCombat/dee-dee-r.dnd-sdk.samples.basiccombat.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5e4f6f20bfbfd39539d9b3a8de84526e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Implemented `BasicCombatManager` to manage a simple two-character, turn-based combat loop with initiative rolls, round transitions, and combat victory conditions.
- Added `PlayerActionMenu` for player interaction during turns, including attack and end-turn functionality.
- Introduced `CombatLogger` to demonstrate message bus subscriptions and log combat events to Unity Console.
- Created assembly definition `dee-dee-r.dnd-sdk.samples.basiccombat.asmdef` for the sample project.