### PR TITLE
Validate `DiceExpression` constructor and add unit test for negative …

### DIFF
--- a/dee-dee-r.dnd-sdk/Core/Systems/DiceRoller.cs
+++ b/dee-dee-r.dnd-sdk/Core/Systems/DiceRoller.cs
@@ -42,7 +42,7 @@ namespace DeeDeeR.DnD.Core.Systems
         /// </returns>
         public RollResult Roll(DiceExpression expression)
         {
-            if (expression.Count <= 0)
+            if (expression.Count == 0)
                 return new RollResult(expression.Modifier);
 
             int  total            = expression.Modifier;

--- a/dee-dee-r.dnd-sdk/Core/Values/DiceExpression.cs
+++ b/dee-dee-r.dnd-sdk/Core/Values/DiceExpression.cs
@@ -19,11 +19,15 @@ namespace DeeDeeR.DnD.Core.Values
         public readonly int      Modifier;
 
         /// <summary>Creates a dice expression (e.g. 2d6+3).</summary>
-        /// <param name="count">Number of dice. Use 0 for a flat value with no dice.</param>
+        /// <param name="count">Number of dice. Use 0 for a flat value with no dice. Must be non-negative.</param>
         /// <param name="die">Die type to roll.</param>
         /// <param name="modifier">Flat modifier added after rolling.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count"/> is negative.</exception>
         public DiceExpression(int count, DieType die, int modifier = 0)
         {
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), count, "Count must be non-negative.");
+
             Count    = count;
             Die      = die;
             Modifier = modifier;

--- a/dee-dee-r.dnd-sdk/Tests/Editor/Values/DiceExpressionTests.cs
+++ b/dee-dee-r.dnd-sdk/Tests/Editor/Values/DiceExpressionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using DeeDeeR.DnD.Core.Enums;
 using DeeDeeR.DnD.Core.Values;
@@ -7,6 +8,15 @@ namespace DeeDeeR.DnD.Tests.Editor.Values
     [TestFixture]
     public class DiceExpressionTests
     {
+        // ── Constructor validation ───────────────────────────────────────────
+
+        [Test]
+        public void Constructor_NegativeCount_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new DiceExpression(-1, DieType.D6));
+        }
+
         // ── ToString ─────────────────────────────────────────────────────────
 
         [Test]


### PR DESCRIPTION
…dice count

- Added validation in `DiceExpression` to throw `ArgumentOutOfRangeException` for negative `count` values.
- Introduced a unit test, `Constructor_NegativeCount_ThrowsArgumentOutOfRangeException`, to ensure proper exception handling.
- Updated XML documentation for `DiceExpression` to include parameter constraints and exception details.
- Adjusted `DiceRoller.Roll` logic to handle `Count == 0` condition explicitly.